### PR TITLE
Partially Editing Images (Issue #1)

### DIFF
--- a/options.js
+++ b/options.js
@@ -157,15 +157,25 @@ function makeGoBut () {
 }
 
 function editKlxn () {
-    if (selectedRows.length == 0) {
-        alert("No images have been selected.");
+    if (selectedRows.length > 0) {
+        // this does not work
+        location.reload();
     }
     else {
         chrome.storage.local.get("klxn", function(items) {
             var klxn =  items.klxn;
+            console.log("new description = " + newDes.value);
+            console.log("new tags = " + newTags.value);
             for (var i = selectedRows.length - 1; i>= 0; i--) {
-                klxn[selectedRows[i]/2].desc = newDes.value;
-                klxn[selectedRows[i]/2].imgTags = newTags.value;
+                // check inputs have values to change
+                if (newDes.value && newTags.value) {
+                    klxn[selectedRows[i]/2].desc = newDes.value;
+                    klxn[selectedRows[i]/2].imgTags = newTags.value;
+                } else if (!newDes.value && newTags.value) {
+                    klxn[selectedRows[i]/2].imgTags = newTags.value;
+                } else if (!newTags.value && newDes.value) {
+                    klxn[selectedRows[i]/2].desc = newDes.value;
+                }
             }
             chrome.storage.local.set({klxn: klxn});
         });

--- a/options.js
+++ b/options.js
@@ -158,14 +158,11 @@ function makeGoBut () {
 
 function editKlxn () {
     if (selectedRows.length > 0) {
-        // this does not work
-        location.reload();
+        alert("No images have been selected.");
     }
     else {
         chrome.storage.local.get("klxn", function(items) {
             var klxn =  items.klxn;
-            console.log("new description = " + newDes.value);
-            console.log("new tags = " + newTags.value);
             for (var i = selectedRows.length - 1; i>= 0; i--) {
                 // check inputs have values to change
                 if (newDes.value && newTags.value) {

--- a/options.js
+++ b/options.js
@@ -157,7 +157,7 @@ function makeGoBut () {
 }
 
 function editKlxn () {
-    if (selectedRows.length > 0) {
+    if (selectedRows.length == 0) {
         alert("No images have been selected.");
     }
     else {


### PR DESCRIPTION
In the event that the user wants to edit only part of the properties of the image (e.g. only description, not the tags), leaving the input box blank replaces the property with blank text. Intuitively, attributes left blank should remain the same and not be erased.

To fix this, I have added a simple check to only make edits if the user included text in the edit property input. 